### PR TITLE
Add queue size and host/port flags

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -75,10 +75,13 @@ python wgp.py --vace-1-3B     # VACE ControlNet 1.3B model
 ### Server Configuration
 ```bash
 --server-port PORT           # Gradio server port (default: 7860)
+--port PORT                  # Alias for --server-port
 --server-name NAME           # Gradio server name (default: localhost)
+--host HOST                  # Alias for --server-name
 --listen                     # Make server accessible on network
 --share                      # Create shareable HuggingFace URL for remote access
 --open-browser               # Open browser automatically when launching
+--queue-size NUMBER          # Maximum tasks allowed in queue (0 for unlimited)
 ```
 
 ### Interface Options


### PR DESCRIPTION
## Summary
- allow limiting task queue size
- add aliases `--host` and `--port`
- update CLI docs for new flags

## Testing
- `python -m py_compile wgp.py`

------
https://chatgpt.com/codex/tasks/task_e_684a05e6b7d08325938610068f4ce258