### PR TITLE
Update default inference steps

### DIFF
--- a/ltx_video/configs/ltxv-13b-0.9.7-dev.original.yaml
+++ b/ltx_video/configs/ltxv-13b-0.9.7-dev.original.yaml
@@ -21,7 +21,7 @@ first_pass:
   rescaling_scale: [1, 0.5, 0.5, 1, 1, 1]
   guidance_timesteps: [1.0, 0.9933, 0.9850, 0.9767, 0.9008, 0.6180]
   skip_block_list:  [[11, 25, 35, 39], [22, 35, 39], [28], [28], [28], [28]]
-  num_inference_steps: 30 #default
+  num_inference_steps: 20 #default
 
 
 second_pass:
@@ -37,5 +37,5 @@ second_pass:
   # rescaling_scale: [1, 1, 1, 1, 1, 1]
   # guidance_timesteps: [1.0, 0.9933, 0.9850, 0.9767, 0.9008, 0.6180]
   # skip_block_list:  [[42], [42], [42], [42], [42], [42]]
-  num_inference_steps: 30 #default
+  num_inference_steps: 20 #default
   strength: 0.85

--- a/ltx_video/configs/ltxv-13b-0.9.7-dev.yaml
+++ b/ltx_video/configs/ltxv-13b-0.9.7-dev.yaml
@@ -19,7 +19,7 @@ first_pass:
   rescaling_scale: [1, 1, 0.5, 0.5, 1, 1, 1]
   guidance_timesteps: [1.0, 0.996,  0.9933, 0.9850, 0.9767, 0.9008, 0.6180]
   skip_block_list: [[], [11, 25, 35, 39], [22, 35, 39], [28], [28], [28], [28]]
-  num_inference_steps: 30
+  num_inference_steps: 20
   skip_final_inference_steps: 3
   cfg_star_rescale: true
 
@@ -29,6 +29,6 @@ second_pass:
   rescaling_scale: [1]
   guidance_timesteps: [1.0]
   skip_block_list: [27]
-  num_inference_steps: 30
+  num_inference_steps: 20
   skip_initial_inference_steps: 17
   cfg_star_rescale: true

--- a/ltx_video/configs/ltxv-2b-0.9.6-dev.yaml
+++ b/ltx_video/configs/ltxv-2b-0.9.6-dev.yaml
@@ -4,7 +4,7 @@ guidance_scale: 3
 stg_scale: 1
 rescaling_scale: 0.7
 skip_block_list: [19]
-num_inference_steps: 40
+num_inference_steps: 20
 stg_mode: "attention_values" # options: "attention_values", "attention_skip", "residual", "transformer_block"
 decode_timestep: 0.05
 decode_noise_scale: 0.025

--- a/ltx_video/configs/ltxv-2b-0.9.6-distilled.yaml
+++ b/ltx_video/configs/ltxv-2b-0.9.6-distilled.yaml
@@ -4,7 +4,7 @@ guidance_scale: 3
 stg_scale: 1
 rescaling_scale: 0.7
 skip_block_list: [19]
-num_inference_steps: 8
+num_inference_steps: 20
 stg_mode: "attention_values" # options: "attention_values", "attention_skip", "residual", "transformer_block"
 decode_timestep: 0.05
 decode_noise_scale: 0.025

--- a/wgp.py
+++ b/wgp.py
@@ -1744,7 +1744,7 @@ def get_default_settings(filename):
             # use the lowest available resolution by default
             "resolution": "512x512",
             "video_length": 81,
-            "num_inference_steps": 30,
+            "num_inference_steps": 20,
             "seed": -1,
             "repeat_generation": 1,
             "multi_images_gen_type": 0,
@@ -4913,7 +4913,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                 else:
                     video_length = gr.Slider(5, 193, value=ui_defaults.get("video_length", 81), step=4, label="Number of frames (16 = 1s)", interactive= True)
             with gr.Row(visible = not ltxv_distilled) as inference_steps_row:                                       
-                num_inference_steps = gr.Slider(1, 100, value=ui_defaults.get("num_inference_steps",30), step=1, label="Number of Inference Steps")
+                num_inference_steps = gr.Slider(1, 100, value=ui_defaults.get("num_inference_steps",20), step=1, label="Number of Inference Steps")
 
 
 


### PR DESCRIPTION
## Summary
- change default inference steps to 20 in the web UI
- update all model configuration files to use 20 steps

## Testing
- `python -m py_compile wgp.py`
- `yamllint ltx_video/configs/*.yaml` *(fails: various lint warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a88c0b3b08325a96b68712f7e55a6