### PR TITLE
Fix export_to_current_video_engine inputs

### DIFF
--- a/preprocessing/matanyone/app.py
+++ b/preprocessing/matanyone/app.py
@@ -677,7 +677,7 @@ def display(tabs, model_choice, vace_video_input, vace_video_mask, vace_image_re
                                 export_to_current_video_engine_btn = gr.Button("Export to current Video Input and Video Mask", visible= False)
                     
                 export_to_vace_video_14B_btn.click( fn=teleport_to_vace_14B, inputs=[], outputs=[tabs, model_choice]).then(
-                    fn=export_to_current_video_engine, inputs= [foreground_video_output, alpha_video_output], outputs= [video_prompt_video_guide_trigger, vace_video_input, vace_video_mask])
+                    fn=export_to_current_video_engine, inputs= [model_choice, foreground_video_output, alpha_video_output], outputs= [video_prompt_video_guide_trigger, vace_video_input, vace_video_mask])
                 
                 export_to_current_video_engine_btn.click(  fn=export_to_current_video_engine, inputs= [model_choice, foreground_video_output, alpha_video_output], outputs= [vace_video_input, vace_video_mask]).then( #video_prompt_video_guide_trigger, 
                     fn=teleport_to_video_tab, inputs= [], outputs= [tabs])


### PR DESCRIPTION
## Summary
- pass model choice in the `export_to_vace_video_14B_btn` callback

## Testing
- `python -m py_compile preprocessing/matanyone/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8b7cf0c08325a65e9cc8c7a596a8