### PR TITLE
Add NSFW moderation filter

### DIFF
--- a/wan/utils/__init__.py
+++ b/wan/utils/__init__.py
@@ -1,8 +1,10 @@
 from .fm_solvers import (FlowDPMSolverMultistepScheduler, get_sampling_sigmas,
                          retrieve_timesteps)
 from .fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .nsfw import contains_nsfw
 
 __all__ = [
     'HuggingfaceTokenizer', 'get_sampling_sigmas', 'retrieve_timesteps',
-    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler'
+    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler',
+    'contains_nsfw'
 ]

--- a/wan/utils/nsfw.py
+++ b/wan/utils/nsfw.py
@@ -1,0 +1,33 @@
+from typing import Optional
+from PIL import Image
+import torch
+from transformers import pipeline
+
+_nsfw_pipeline: Optional[object] = None
+
+
+def load_nsfw_pipeline() -> object:
+    """Lazy load the NSFW detection pipeline."""
+    global _nsfw_pipeline
+    if _nsfw_pipeline is None:
+        _nsfw_pipeline = pipeline(
+            "image-classification",
+            model="Falconsai/nsfw_image_detection",
+            device=0 if torch.cuda.is_available() else -1,
+        )
+    return _nsfw_pipeline
+
+
+def contains_nsfw(frames: torch.Tensor) -> bool:
+    """Return True if any frame is flagged NSFW."""
+    classifier = load_nsfw_pipeline()
+    for idx in range(frames.shape[1]):
+        frame = frames[:, idx]
+        frame = ((frame + 1) / 2).clamp(0, 1)
+        img = Image.fromarray((frame.permute(1, 2, 0).cpu().numpy() * 255).astype("uint8"))
+        result = classifier(img, top_k=1)[0]
+        label = result.get("label")
+        score = result.get("score", 0)
+        if label in {"porn", "sexy", "hentai"} and score > 0.5:
+            return True
+    return False

--- a/wgp.py
+++ b/wgp.py
@@ -3431,6 +3431,11 @@ def generate_video(
                     file_name = f"{time_flag}_seed{seed}_{sanitize_file_name(save_prompt[:100]).strip()}.mp4"
                 video_path = os.path.join(save_path, file_name)
 
+                from wan.utils import contains_nsfw
+                if contains_nsfw(sample):
+                    send_cmd("info", "content was flagged inappropriate and removed")
+                    sample = torch.zeros_like(sample)
+
                 if audio_guide == None:
                     cache_video( tensor=sample[None], save_file=video_path, fps=output_fps, nrow=1, normalize=True, value_range=(-1, 1))
                 else:


### PR DESCRIPTION
## Summary
- add NSFW detection helper using a HF pipeline
- expose new helper from utils package
- check video frames for NSFW content before saving

## Testing
- `python -m py_compile wgp.py wan/utils/nsfw.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a922c5078832584e154f1c42e2ed2