### PR TITLE
Add default negative prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ WanGP supports the Wan (and derived models), Hunyuan Video and LTV Video models 
 ### June 11 2025: WanGP v5.5
 👋 *Hunyuan Video Custom Audio*: it is similar to Hunyuan Video Avatar except there isn't any lower limit on the number of frames and you can use your reference images in a different context than the image itself\
 *Hunyuan Video Custom Edit*: Hunyuan Video Controlnet, use it to do inpainting and replace a person in a video while still keeping his poses. Similar to Vace but less restricted than the Wan models in terms of content...
+* Default negative prompt is now automatically applied to reduce NSFW content.
 
 
 ### June 6 2025: WanGP v5.41

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### June 11 2025: WanGP v5.5
 👋 *Hunyuan Video Custom Audio*: it is similar to Hunyuan Video Avatar excpet there isn't any lower limit on the number of frames and you can use your reference images in a different context than the image itself\
 *Hunyuan Video Custom Edit*: Hunyuan Video Controlnet, use it to do inpainting and replace a person in a video while still keeping his poses. Similar to Vace but less restricted than the Wan models in terms of content...
+* Added a default negative prompt to reduce NSFW results by filtering terms like `nude` and `porn`.
 
 ### June 6 2025: WanGP v5.41
 👋 Bonus release: Support for **AccVideo** Lora to speed up x2 Video generations in Wan models. Check the Loras documentation to get the usage instructions of AccVideo.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2,6 +2,8 @@
 
 This document covers all available command line options for WanGP.
 
+The `--negative-prompt` option now defaults to a string that filters common NSFW terms like `nude`, `porn`, and `explicit` content.
+
 ## Basic Usage
 
 ```bash

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -153,6 +153,7 @@ A cat sitting on a windowsill watching rain, cozy atmosphere, soft lighting
 - Mention lighting and atmosphere
 - Describe the setting in detail
 - Use quality modifiers (high quality, detailed, etc.)
+- A default negative prompt is applied to filter NSFW terms like `nude`, `porn`, and `explicit`.
 
 ## Next Steps
 

--- a/i2v_inference.py
+++ b/i2v_inference.py
@@ -22,6 +22,10 @@ except ImportError:
 
 DATA_DIR = "ckpts"
 
+DEFAULT_NEGATIVE_PROMPT = (
+    "nsfw, nude, nudity, naked, sexy, sex, porn, explicit, erotic"
+)
+
 # --------------------------------------------------
 # HELPER FUNCTIONS
 # --------------------------------------------------
@@ -391,7 +395,12 @@ def parse_args():
 
     # Generation Options
     parser.add_argument("--prompt", type=str, default=None, required=True, help="Prompt for generation")
-    parser.add_argument("--negative-prompt", type=str, default="", help="Negative prompt")
+    parser.add_argument(
+        "--negative-prompt",
+        type=str,
+        default=DEFAULT_NEGATIVE_PROMPT,
+        help="Negative prompt",
+    )
     parser.add_argument("--resolution", type=str, default="832x480", help="WxH")
     parser.add_argument("--frames", type=int, default=64, help="Number of frames (16=1s if fps=16). Must be multiple of 4 +/- 1 in WAN.")
     parser.add_argument("--steps", type=int, default=30, help="Number of denoising steps.")
@@ -517,7 +526,7 @@ def main():
     )
 
     # Negative prompt
-    negative_prompt = args.negative_prompt or ""
+    negative_prompt = args.negative_prompt or DEFAULT_NEGATIVE_PROMPT
 
     # Sanity check resolution
     if "*" in args.resolution.lower():

--- a/wgp.py
+++ b/wgp.py
@@ -45,6 +45,9 @@ PROMPT_VARS_MAX = 10
 
 target_mmgp_version = "3.4.8"
 WanGP_version = "5.5"
+DEFAULT_NEGATIVE_PROMPT = (
+    "nsfw, nude, nudity, naked, sexy, sex, porn, explicit, erotic"
+)
 prompt_enhancer_image_caption_model, prompt_enhancer_image_caption_processor, prompt_enhancer_llm_model, prompt_enhancer_llm_tokenizer = None, None, None, None
 
 from importlib.metadata import version
@@ -1753,7 +1756,7 @@ def get_default_settings(filename):
             "embedded_guidance_scale" : 6.0,
             "audio_guidance_scale": 5.0,
             "flow_shift": get_default_flow(filename, i2v),
-            "negative_prompt": "",
+            "negative_prompt": DEFAULT_NEGATIVE_PROMPT,
             "activated_loras": [],
             "loras_multipliers": "",
             "tea_cache_setting": 2.5,
@@ -4952,7 +4955,10 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             embedded_guidance_scale = gr.Slider(1.0, 20.0, value=6.0, step=0.5, label="Embedded Guidance Scale", visible=(hunyuan_t2v or hunyuan_i2v))
                             flow_shift = gr.Slider(0.0, 25.0, value=ui_defaults.get("flow_shift",3), step=0.1, label="Shift Scale") 
                         with gr.Row():
-                            negative_prompt = gr.Textbox(label="Negative Prompt", value=ui_defaults.get("negative_prompt", "") )
+                            negative_prompt = gr.Textbox(
+                                label="Negative Prompt",
+                                value=ui_defaults.get("negative_prompt", DEFAULT_NEGATIVE_PROMPT),
+                            )
                 with gr.Tab("Loras"):
                     with gr.Column(visible = True): #as loras_column:
                         gr.Markdown("<B>Loras can be used to create special effects on the video by mentioning a trigger word in the Prompt. You can save Loras combinations in presets.</B>")


### PR DESCRIPTION
## Summary
- apply a default negative prompt to filter NSFW content
- mention the new default in documentation
- update CLI docs about the default negative prompt

## Testing
- `python -m py_compile wgp.py i2v_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9ff19f8c8325a9fa8804b3534c99