### PR TITLE
Add admin mode flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,6 +85,7 @@ python wgp.py --vace-1-3B     # VACE ControlNet 1.3B model
 ```bash
 --lock-config                # Prevent modifying video engine configuration from interface
 --theme THEME_NAME           # UI theme: "default" or "gradio"
+--admin                     # Enable admin tabs
 ```
 
 ## File and Directory Options


### PR DESCRIPTION
## Summary
- add `--admin` CLI option to enable privileged tabs
- update docs with `--admin`
- show admin-only tabs when `--admin` is used
- guard tab selection logic when admin mode isn't active
- add noop `vmc_event_handler` default

## Testing
- `python -m py_compile wgp.py`

------
https://chatgpt.com/codex/tasks/task_e_684aa326533483259109c873dc84ad66