### PR TITLE
Fix NSFW pipeline processor mode

### DIFF
--- a/wan/utils/nsfw.py
+++ b/wan/utils/nsfw.py
@@ -13,6 +13,7 @@ def load_nsfw_pipeline() -> object:
         _nsfw_pipeline = pipeline(
             "image-classification",
             model="Falconsai/nsfw_image_detection",
+            use_fast=False,
             device=0 if torch.cuda.is_available() else -1,
         )
     return _nsfw_pipeline


### PR DESCRIPTION
## Summary
- keep `Falconsai/nsfw_image_detection` using the slow image processor to avoid future warnings

## Testing
- `flake8 wan/utils/nsfw.py` *(fails: W293, E731, W391, E501)*

------
https://chatgpt.com/codex/tasks/task_e_684aa3a73a00832584e3c008ce2a6938