### PR TITLE
Fix simplemode checkbox update

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -4206,7 +4206,7 @@ def switch_simple(state, new_simple):
     state["advanced"] = not new_simple
     return (
         str(time.time()),
-        gr.Checkbox.update(value=not new_simple, visible=not new_simple),
+        gr.update(value=not new_simple, visible=not new_simple),
         gr.Row(visible=not new_simple),
         gr.Row(visible=not new_simple),
         gr.Row(visible=not new_simple),


### PR DESCRIPTION
## Summary
- fix `switch_simple` to use `gr.update` instead of the nonexistent `gr.Checkbox.update`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684aaf67ac0c8325a4bc15ac65d4b843