### PR TITLE
Add root_path flag to wgp

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -80,6 +80,7 @@ python wgp.py --vace-1-3B     # VACE ControlNet 1.3B model
 --server-name NAME           # Gradio server name (default: localhost)
 --listen                     # Make server accessible on network
 --share                      # Create shareable HuggingFace URL for remote access
+--root_path PATH            # Root path prefix for hosting under a subpath
 --open-browser               # Open browser automatically when launching
 ```
 
@@ -124,6 +125,9 @@ python wgp.py --share --theme gradio --open-browser
 
 # Locked configuration for public use
 python wgp.py --lock-config --share
+
+# Run under a specific context path
+python wgp.py --server-port 8080 --root_path /music
 ```
 
 ### Advanced Performance Examples

--- a/wgp.py
+++ b/wgp.py
@@ -1336,6 +1336,12 @@ def _parse_args():
         help="Server name"
     )
     parser.add_argument(
+        "--root_path",
+        type=str,
+        default="",
+        help="Root path for running the app under a subpath"
+    )
+    parser.add_argument(
         "--gpu",
         type=str,
         default="",
@@ -6214,4 +6220,10 @@ if __name__ == "__main__":
         else:
             url = "http://" + server_name 
         webbrowser.open(url + ":" + str(server_port), new = 0, autoraise = True)
-    demo.launch(server_name=server_name, server_port=server_port, share=args.share, allowed_paths=[save_path])
+    demo.launch(
+        server_name=server_name,
+        server_port=server_port,
+        share=args.share,
+        allowed_paths=[save_path],
+        root_path=args.root_path if len(args.root_path) > 0 else None,
+    )


### PR DESCRIPTION
## Summary
- add `--root_path` option in `wgp.py`
- pass `root_path` to `gradio.Interface.launch`
- document the new flag and add an example of running under a context path

## Testing
- `python -m py_compile wgp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0a0acb9c832588eae7c7813ea9e8