### PR TITLE
Allow Video Mask Creator during generation

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -5801,12 +5801,7 @@ def select_tab(tab_state, evt:gr.SelectData):
     if old_tab_no == tab_video_mask_creator:
         vmc_event_handler(False)
     elif new_tab_no == tab_video_mask_creator:
-        if gen_in_progress:
-            gr.Info("Unable to access this Tab while a Generation is in Progress. Please come back later")
-            tab_state["tab_no"] = 0
-            return gr.Tabs(selected="video_gen")
-        else:
-            vmc_event_handler(True)
+        vmc_event_handler(True)
     tab_state["tab_no"] = new_tab_no
     return gr.Tabs()
 


### PR DESCRIPTION
## Summary
- allow switching to the Video Mask Creator tab even while a generation is running

## Testing
- `pytest -q`
- `python -m py_compile wgp.py`


------
https://chatgpt.com/codex/tasks/task_e_684cb86a5a888325be8f8a07063da1a8