### PR TITLE
Fix video matting device mismatch

### DIFF
--- a/preprocessing/matanyone/matanyone_wrapper.py
+++ b/preprocessing/matanyone/matanyone_wrapper.py
@@ -41,14 +41,15 @@ def matanyone(processor, frames_np, mask, r_erode=0, r_dilate=0, n_warmup=10):
     if r_erode > 0:
         mask = gen_erosion(mask, r_erode, r_erode)
 
-    mask = torch.from_numpy(mask).cuda()
+    device = getattr(processor.network, "device", torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+    mask = torch.from_numpy(mask).to(device)
 
     frames_np = [frames_np[0]]* n_warmup + frames_np
 
     frames = []
     phas = []
     for ti, frame_single in tqdm.tqdm(enumerate(frames_np)):
-        image = to_tensor(frame_single).cuda().float()
+        image = to_tensor(frame_single).to(device).float()
 
         if ti == 0:
             output_prob = processor.step(image, mask, objects=objects)      # encode given mask


### PR DESCRIPTION
## Summary
- fix CUDA device mismatch in MatAnyone wrapper

## Testing
- `python -m py_compile preprocessing/matanyone/matanyone_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_e_684cd9412a288325abccc907b424102b